### PR TITLE
fix(navigation): variometer descending values does not fit to widget

### DIFF
--- a/apps/mapview/src/app/components/widgets/variometer-widget/variometer-widget.component.scss
+++ b/apps/mapview/src/app/components/widgets/variometer-widget/variometer-widget.component.scss
@@ -26,6 +26,6 @@
     text-align: right;
     font-family: monospace;
     font-size: calc(1rem * var(--widget-font-size-ratio));
-    width: calc(2rem * var(--widget-font-size-ratio));
+    min-width: calc(3.25rem * var(--widget-font-size-ratio));
   }
 }


### PR DESCRIPTION
increase of value width and use min-width just in case

closes #96