### PR TITLE
feat(widgets): add support for gamepad blocking / unblocking

### DIFF
--- a/apps/mapview/src/app/app.component.html
+++ b/apps/mapview/src/app/app.component.html
@@ -7,3 +7,4 @@
 <laamap-navigation-next-point-widget />
 <laamap-center-icon></laamap-center-icon>
 <laamap-global-search></laamap-global-search>
+<laamap-gamepad-widget></laamap-gamepad-widget>

--- a/apps/mapview/src/app/app.component.ts
+++ b/apps/mapview/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { environment } from '../environments/environment';
 import { CenterIconComponent } from './components/center-icon/center-icon.component';
 import { GlobalSearchComponent } from './components/global-search/global-search.component';
 import { AltimeterWidgetComponent } from './components/widgets/altimeter-widget/altimeter-widget.component';
+import { GamepadWidgetComponent } from './components/widgets/gamepad-widget/gamepad-widget.component';
 import { NavigationGoalWidgetComponent } from './components/widgets/navigation-goal-widget/navigation-goal-widget.component';
 import { NavigationNextPointWidgetComponent } from './components/widgets/navigation-next-point-widget/navigation-next-point-widget.component';
 import { RadarWidgetComponent } from './components/widgets/radar-widget/radar-widget.component';
@@ -29,6 +30,7 @@ import { generalFeature } from './store/features/settings/general.feature';
     NavigationNextPointWidgetComponent,
     CenterIconComponent,
     GlobalSearchComponent,
+    GamepadWidgetComponent,
   ],
 })
 export class AppComponent implements AfterViewInit {

--- a/apps/mapview/src/app/components/center-icon/center-icon.component.ts
+++ b/apps/mapview/src/app/components/center-icon/center-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 
 import { GamepadHandlerService } from '../../services/gamepad-handler/gamepad-handler.service';
@@ -9,11 +9,10 @@ import { GamepadHandlerService } from '../../services/gamepad-handler/gamepad-ha
   styleUrls: ['./center-icon.component.scss'],
   standalone: true,
   imports: [MatIconModule],
+  host: {
+    '[style.visibility]': 'gamePadService.gamePadChangingViewVisibility()',
+  },
 })
 export class CenterIconComponent {
   readonly gamePadService = inject(GamepadHandlerService);
-
-  @HostBinding('style.visibility') get visibility() {
-    return this.gamePadService.gamePadChangingView ? 'visible' : 'hidden';
-  }
 }

--- a/apps/mapview/src/app/components/dialogs/settings-dialog/gamepad-settings/gamepad-settings.component.cy.ts
+++ b/apps/mapview/src/app/components/dialogs/settings-dialog/gamepad-settings/gamepad-settings.component.cy.ts
@@ -1,3 +1,4 @@
+import { signal } from '@angular/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of, repeat } from 'rxjs';
 
@@ -20,7 +21,7 @@ describe(GamepadSettingsComponent.name, () => {
         {
           provide: GamepadHandlerService,
           useValue: {
-            settingMode: false,
+            settingMode: signal(false),
             gamePadActive$: of([
               {
                 index: 0,
@@ -41,11 +42,11 @@ describe(GamepadSettingsComponent.name, () => {
       '#mat-expansion-panel-header-0 > .mat-content > .mat-expansion-panel-header-title',
     ).click();
     cy.get(
-      '#mat-expansion-panel-header-6 > .mat-content > .mat-expansion-panel-header-title',
+      '#mat-expansion-panel-header-7 > .mat-content > .mat-expansion-panel-header-title',
     ).click();
-    cy.get('#mat-input-26').should('have.value', 0); // init value
-    cy.get('#mat-input-26').click();
-    cy.get('#mat-input-26').should('have.value', 10); // value from gamepad
+    cy.get('#mat-input-31').should('have.value', 0); // init value
+    cy.get('#mat-input-31').click();
+    cy.get('#mat-input-31').should('have.value', 10); // value from gamepad
 
     const dispatchValue = Object.entries(gamepadInitialState.shortCuts).reduce(
       (res, val) => ({

--- a/apps/mapview/src/app/components/dialogs/settings-dialog/gamepad-settings/gamepad-settings.component.ts
+++ b/apps/mapview/src/app/components/dialogs/settings-dialog/gamepad-settings/gamepad-settings.component.ts
@@ -74,7 +74,7 @@ export class GamepadSettingsComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.gamepadService.gamePadActive$
       .pipe(
-        filter((val) => !!val && this.gamepadService.settingMode),
+        filter((val) => !!val && this.gamepadService.settingMode()),
         untilDestroyed(this),
       )
       .subscribe({
@@ -83,11 +83,11 @@ export class GamepadSettingsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.gamepadService.settingMode = false;
+    this.gamepadService.settingMode.set(false);
   }
 
   expandedChange(value: boolean) {
-    this.gamepadService.settingMode = value;
+    this.gamepadService.settingMode.set(value);
   }
 
   private processGamePadInput(input: ActiveGamePadButtons | null): void {

--- a/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.html
+++ b/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.html
@@ -1,0 +1,12 @@
+<ng-template transloco let-t translocoRead="widgets.navigation">
+  <div
+    class="container"
+    cdkDrag
+    (cdkDragEnded)="dragEnded($event)"
+    cdkDragBoundary="body"
+    [cdkDragFreeDragPosition]="safePosition()"
+    [cdkDragStartDelay]="1000"
+  >
+    <mat-icon [class.active]="!disabled()">sports_esports</mat-icon>
+  </div>
+</ng-template>

--- a/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.scss
+++ b/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.scss
@@ -1,0 +1,20 @@
+.container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 0.3rem;
+  padding: 0.25rem 0.75rem;
+  cursor: move;
+  z-index: 2;
+  background-color: var(--base-color);
+
+  mat-icon {
+    font-size: 2rem;
+    width: 1ch;
+    color: var(--non-active-color);
+
+    &.active {
+      color: var(--active-color);
+    }
+  }
+}

--- a/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.ts
+++ b/apps/mapview/src/app/components/widgets/gamepad-widget/gamepad-widget.component.ts
@@ -1,0 +1,48 @@
+import { CdkDrag, CdkDragEnd } from '@angular/cdk/drag-drop';
+import { Component, ElementRef, inject, viewChildren } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { TranslocoModule } from '@ngneat/transloco';
+import { TranslocoLocaleModule } from '@ngneat/transloco-locale';
+import { Store } from '@ngrx/store';
+import { map } from 'rxjs';
+
+import { GamepadHandlerService } from '../../../services/gamepad-handler/gamepad-handler.service';
+import { WidgetSafePositionService } from '../../../services/widget-safe-position/widget-safe-position.service';
+import { gamepadWidgetActions } from '../../../store/actions/widgets.actions';
+import { gamepadFeature } from '../../../store/features/settings/gamepad.feature';
+
+@Component({
+  selector: 'laamap-gamepad-widget',
+  templateUrl: './gamepad-widget.component.html',
+  styleUrls: ['./gamepad-widget.component.scss'],
+  standalone: true,
+  imports: [TranslocoModule, CdkDrag, TranslocoLocaleModule, MatIconModule],
+  host: { '[style.visibility]': 'gamePadService.gamePadVisibility()' },
+})
+export class GamepadWidgetComponent {
+  containers = viewChildren<CdkDrag, ElementRef<HTMLElement>>(CdkDrag, {
+    read: ElementRef,
+  });
+  private readonly safePositionService = inject(WidgetSafePositionService);
+  private readonly store = inject(Store);
+  readonly gamePadService = inject(GamepadHandlerService);
+
+  disabled = this.gamePadService.disabled.asReadonly();
+  safePosition = this.safePositionService.safePosition(
+    this.store
+      .select(gamepadFeature.selectWidget)
+      .pipe(map((val) => val.position)),
+    this.containers,
+  );
+
+  dragEnded(event: CdkDragEnd): void {
+    this.store.dispatch(
+      gamepadWidgetActions.positionMoved({
+        position: {
+          x: event.source.element.nativeElement.getBoundingClientRect().x,
+          y: event.source.element.nativeElement.getBoundingClientRect().y,
+        },
+      }),
+    );
+  }
+}

--- a/apps/mapview/src/app/services/gamepad-handler/gamepad-handler.service.spec.ts
+++ b/apps/mapview/src/app/services/gamepad-handler/gamepad-handler.service.spec.ts
@@ -110,6 +110,7 @@ describe('GamepadHandlerService', () => {
 
   it('close dialog using gamepad', (done) => {
     service.init(null as unknown as Map);
+    service.disabled.set(false);
     service['gamePadSubj$'].next([
       {
         axes: [0, 0.7, 0, 0],

--- a/apps/mapview/src/app/services/gamepad-handler/gamepad-handler.types.ts
+++ b/apps/mapview/src/app/services/gamepad-handler/gamepad-handler.types.ts
@@ -30,4 +30,5 @@ export type GamePadShortCutName =
   | 'closeDialog'
   | 'dialogDo'
   | 'nextField'
+  | 'disabled'
   | 'previousField';

--- a/apps/mapview/src/app/services/widget-safe-position/widget-safe-position.service.ts
+++ b/apps/mapview/src/app/services/widget-safe-position/widget-safe-position.service.ts
@@ -1,4 +1,5 @@
-import { ElementRef, Injectable } from '@angular/core';
+import { ElementRef, Injectable, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import {
   BehaviorSubject,
   Observable,
@@ -46,6 +47,15 @@ export class WidgetSafePositionService {
       ),
       map((val) => this.getSafePosition(val[2][0], val[0], val[1])),
     );
+  }
+
+  safePosition(
+    position$: Observable<{ x: number; y: number }>,
+    widget: Signal<readonly ElementRef<HTMLElement>[]>,
+  ): Signal<{ x: number; y: number }> {
+    return toSignal(this.safePosition$(position$, toObservable(widget)), {
+      initialValue: { x: 0, y: 0 },
+    });
   }
 
   private getSafePosition(

--- a/apps/mapview/src/app/store/actions/widgets.actions.ts
+++ b/apps/mapview/src/app/store/actions/widgets.actions.ts
@@ -65,3 +65,12 @@ export const varioMeterWidgetActions = createActionGroup({
     }>(),
   },
 });
+
+export const gamepadWidgetActions = createActionGroup({
+  source: 'Gamepad meter widget',
+  events: {
+    'Position moved': props<{
+      position: { x: number; y: number };
+    }>(),
+  },
+});

--- a/apps/mapview/src/app/store/features/settings/gamepad.feature.ts
+++ b/apps/mapview/src/app/store/features/settings/gamepad.feature.ts
@@ -5,10 +5,14 @@ import {
   IGamePadActions,
 } from '../../../services/gamepad-handler/gamepad-handler.types';
 import { gamePadSettingsActions } from '../../actions/settings.actions';
+import { gamepadWidgetActions } from '../../actions/widgets.actions';
 
 export const gamepadInitialState: {
   shortCuts: {
     [key in GamePadShortCutName]: IGamePadActions;
+  };
+  widget: {
+    position: { x: number; y: number };
   };
 } = {
   shortCuts: {
@@ -110,6 +114,16 @@ export const gamepadInitialState: {
       index: 0,
       button: 12,
     },
+    disabled: {
+      index: 0,
+      button: 3,
+    },
+  },
+  widget: {
+    position: {
+      x: 400,
+      y: 200,
+    },
   },
 };
 
@@ -122,6 +136,13 @@ export const gamepadFeature = createFeature({
       (state, { value }): typeof gamepadInitialState => ({
         ...state,
         shortCuts: value,
+      }),
+    ),
+    on(
+      gamepadWidgetActions.positionMoved,
+      (state, { position }): typeof gamepadInitialState => ({
+        ...state,
+        widget: { ...state.widget, position },
       }),
     ),
   ),

--- a/apps/mapview/src/assets/i18n/en.json
+++ b/apps/mapview/src/assets/i18n/en.json
@@ -148,7 +148,8 @@
       "xMoveRight": "Move right",
       "xMoveTop": "Move up",
       "zoomOut": "Zoom out",
-      "openGlobalSearch": "Open global search"
+      "openGlobalSearch": "Open global search",
+      "disabled": "Block/Unblock"
     },
     "contactMe": {
       "title": "Contact",

--- a/apps/mapview/src/assets/i18n/sk.json
+++ b/apps/mapview/src/assets/i18n/sk.json
@@ -148,7 +148,8 @@
       "xMoveRight": "Posun do prava",
       "xMoveTop": "Posun hore",
       "zoomOut": "Vzdialiť",
-      "openGlobalSearch": "Otvor globálne hladanie"
+      "openGlobalSearch": "Otvor globálne hladanie",
+      "disabled": "Blokovanie/Odblokovanie"
     },
     "contactMe": {
       "title": "Kontakt",

--- a/apps/mapview/src/styles.scss
+++ b/apps/mapview/src/styles.scss
@@ -9,6 +9,8 @@
   --direction-line-odd-color: white;
   --base-color: white;
   --strong-border-color: black;
+  --active-color: limegreen;
+  --non-active-color: red;
 }
 
 body,


### PR DESCRIPTION
when gamepad can be coincidently pushed it can be blocked until unblock button is pressed and can be blocked again with that button

closes #191