### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ftp-deploy.yml
+++ b/.github/workflows/ftp-deploy.yml
@@ -1,4 +1,6 @@
 name: deploy navigation to stork web
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jobes/laamap/security/code-scanning/6](https://github.com/jobes/laamap/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily interacts with the repository contents and does not appear to require write access. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required for specific actions, they can be added later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
