### PR TITLE
feat(hardware): implement Wake Lock API to prevent display sleep

### DIFF
--- a/apps/rpi-instruments-server/main-page.html
+++ b/apps/rpi-instruments-server/main-page.html
@@ -59,7 +59,7 @@
       requestWakeLock();
       // Re-request wake lock on visibility change
       document.addEventListener('visibilitychange', () => {
-        if (wakeLock !== null && document.visibilityState === 'visible') {
+        if (document.visibilityState === 'visible') {
           requestWakeLock();
         }
       });

--- a/apps/rpi-instruments-server/main-page.html
+++ b/apps/rpi-instruments-server/main-page.html
@@ -59,7 +59,7 @@
       requestWakeLock();
       // Re-request wake lock on visibility change
       document.addEventListener('visibilitychange', async () => {
-        if (document.visibilityState === 'visible') {
+        if (document.visibilityState === 'visible' && wakeLock?.released) {
           requestWakeLock();
         } else if (document.visibilityState === 'hidden' && wakeLock) {
           try {

--- a/apps/rpi-instruments-server/main-page.html
+++ b/apps/rpi-instruments-server/main-page.html
@@ -58,9 +58,16 @@
       // Request wake lock on page load
       requestWakeLock();
       // Re-request wake lock on visibility change
-      document.addEventListener('visibilitychange', () => {
+      document.addEventListener('visibilitychange', async () => {
         if (document.visibilityState === 'visible') {
           requestWakeLock();
+        } else if (document.visibilityState === 'hidden' && wakeLock) {
+          try {
+            await wakeLock.release();
+          } catch (err) {
+            // Ignore release errors
+          }
+          wakeLock = null;
         }
       });
     </script>

--- a/apps/rpi-instruments-server/main-page.html
+++ b/apps/rpi-instruments-server/main-page.html
@@ -43,6 +43,27 @@
     </style>
   </head>
   <body>
+    <script>
+      // Prevent display from sleeping using Wake Lock API if available
+      let wakeLock = null;
+      async function requestWakeLock() {
+        try {
+          if ('wakeLock' in navigator) {
+            wakeLock = await navigator.wakeLock.request('screen');
+          }
+        } catch (err) {
+          // Wake Lock request failed - ignore
+        }
+      }
+      // Request wake lock on page load
+      requestWakeLock();
+      // Re-request wake lock on visibility change
+      document.addEventListener('visibilitychange', () => {
+        if (wakeLock !== null && document.visibilityState === 'visible') {
+          requestWakeLock();
+        }
+      });
+    </script>
     <h1>{{ title }} engine and instruments</h1>
 
     <table>


### PR DESCRIPTION
This pull request introduces a new feature to the `main-page.html` file to improve the user experience by preventing the device's display from sleeping while the page is open. The implementation uses the Wake Lock API to keep the screen awake, ensuring uninterrupted visibility of the instrument panel.

Display wake lock feature:

* Added a script that requests a screen wake lock using the Wake Lock API when the page loads, and re-requests it when the page becomes visible again after being hidden. This prevents the display from sleeping while the page is in use.